### PR TITLE
Update CreateQuote Http handler to get the userID from token

### DIFF
--- a/internal/adapter/handler/http/router.go
+++ b/internal/adapter/handler/http/router.go
@@ -76,7 +76,7 @@ func NewRouter(
 			}
 		}
 
-		quote := v1.Group("/quotes")
+		quote := v1.Group("/quotes").Use(authMiddleware(token))
 		{
 			quote.POST("/", quoteHandler.CreateQuote)
 			quote.GET("all/", quoteHandler.ListQuotes)


### PR DESCRIPTION
closes #23

## Summary by Sourcery

Update CreateQuote handler to use authenticated user's ID instead of client ID from form data

New Features:
- Add authentication middleware to quotes endpoint

Bug Fixes:
- Remove client ID input from quote creation form to prevent unauthorized user impersonation

Enhancements:
- Modify quote creation to extract user ID from authentication token