### PR TITLE
Refactor router to handle auth middleware the correct way

### DIFF
--- a/internal/core/service/typeOfService.go
+++ b/internal/core/service/typeOfService.go
@@ -52,7 +52,7 @@ func (s *TypeOfServiceService) CreateTypeOfService(ctx context.Context, t *domai
 		return nil, domain.ErrInternal
 	}
 
-	err = s.cache.DeleteByPrefix(ctx, "typeofservices appointments:*")
+	err = s.cache.DeleteByPrefix(ctx, "typeofservices:*")
 	if err != nil {
 		return nil, domain.ErrInternal
 	}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix cache.DeleteByPrefix argument to use "typeofservices:*" instead of "typeofservices appointments:*"