### PR TITLE
Solo permite un comprobante de pago por cotización

### DIFF
--- a/internal/adapter/storage/postgres/repository/paymentProof.go
+++ b/internal/adapter/storage/postgres/repository/paymentProof.go
@@ -79,6 +79,36 @@ func (r *PaymentProofRepository) GetPaymentProofByID(ctx context.Context, id uui
 	return &paymentProof, nil
 }
 
+// GetPaymentProofByQuoteID selecciona un comprobante por su QuoteID
+func (r *PaymentProofRepository) GetPaymentProofByQuoteID(ctx context.Context, quoteID uuid.UUID) (*domain.PaymentProof, error) {
+	var paymentProof domain.PaymentProof
+
+	query := r.db.QueryBuilder.Select("*").
+		From("\"PaymentProof\"").
+		Where(sq.Eq{"\"quoteId\"": quoteID}).
+		Limit(1)
+
+	sql, args, err := query.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.db.Conn.QueryRow(ctx, sql, args...).Scan(
+		&paymentProof.ID,
+		&paymentProof.QuoteID,
+		&paymentProof.URL,
+		&paymentProof.IsReviewed,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil // No es error, simplemente no hay comprobante aún
+		}
+		return nil, err
+	}
+
+	return &paymentProof, nil
+}
+
 // GetPaymentProofs selects all payment proofs with optional filtering by QuoteID and IsReviewed
 func (r *PaymentProofRepository) GetPaymentProofs(ctx context.Context, filter port.PaymentProofFilter) ([]domain.PaymentProof, error) {
 	var paymentProofs []domain.PaymentProof

--- a/internal/core/port/paymentProof.go
+++ b/internal/core/port/paymentProof.go
@@ -27,6 +27,7 @@ type PaymentProofRepository interface {
 	DeletePaymentProof(ctx context.Context, id uuid.UUID) error
 	// GetPaymentProofByID selects a payment proof by its ID
 	GetPaymentProofByID(ctx context.Context, id uuid.UUID) (*domain.PaymentProof, error)
+	GetPaymentProofByQuoteID(ctx context.Context, quoteID uuid.UUID) (*domain.PaymentProof, error)
 	// GetPaymentProofs selects all payment proofs with optional filtering by QuoteID
 	GetPaymentProofs(ctx context.Context, filter PaymentProofFilter) ([]domain.PaymentProof, error)
 	// Wrap a function in a DB transaction; if fn returns an error, rollback


### PR DESCRIPTION
## Summary by Sourcery

Enforce at most one payment proof per quote by adding repository support for fetching proofs by quote ID and validating uniqueness before creation

Enhancements:
- Add GetPaymentProofByQuoteID method to repository and port interface
- Prevent creation of duplicate payment proofs by returning a conflict error when one already exists